### PR TITLE
Send JSON-encoded posts instead of form-encoded.

### DIFF
--- a/controllers/controllers.php
+++ b/controllers/controllers.php
@@ -249,28 +249,29 @@ $app->post('/post', function() use($app) {
     if($user->micropub_endpoint) {
       $text_content = 'Just ' . $verb . ': ' . $entry->content;
 
-      $mp_request = array(
-        'h' => 'entry',
-        'published' => $published,
-        'created' => $published,
-        'location' => k($params, 'location'),
-        'summary' => $text_content
+      $mp_properties = array(
+        'published' => [$published],
+        'created' => [$published],
+        'summary' => [$text_content]
       );
+      $location = k($params, 'location');
+      if($location) {
+        $mp_properties['location'] = [$location];
+      }
       if($entry->photo_url) {
-        $mp_request['photo'] = $entry->photo_url;
+        $mp_properties['photo'] = [$entry->photo_url];
       }
-      if($user->enable_array_micropub) {
-        $mp_request[$verb] = [
-          'type' => 'h-food',
-          'properties' => [
-            'name' => $entry->content
-          ]
-        ];
-      } else {
-        $mp_request['p3k-food'] = $entry->content;
-        $mp_request['p3k-type'] = $type;
-      }
+      $mp_properties[$verb] = [[
+        'type' => ['h-food'],
+        'properties' => [
+          'name' => $entry->content
+        ]
+      ]];
 
+      $mp_request = array(
+        'type' => ['h-entry'],
+        'properties' => $mp_properties
+      );
       $r = micropub_post($user->micropub_endpoint, $mp_request, $user->access_token);
       $request = $r['request'];
       $response = $r['response'];

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -100,13 +100,12 @@ function micropub_post($endpoint, $params, $access_token) {
   $ch = curl_init();
   curl_setopt($ch, CURLOPT_URL, $endpoint);
   curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-    'Authorization: Bearer ' . $access_token
+    'Authorization: Bearer ' . $access_token,
+    'Content-Type: application/json',
+    'Accept: application/json'
   ));
   curl_setopt($ch, CURLOPT_POST, true);
-  $post = http_build_query(array_merge(array(
-    'access_token' => $access_token,
-    'h' => 'entry'
-  ), $params));
+  $post = json_encode($params);
   curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
   curl_setopt($ch, CURLOPT_HEADER, true);


### PR DESCRIPTION
Micropub form-encoded requests can't have nested objects like ate[type]=[h-food]

NOTE: currently not including `access_token` in the JSON payload. That might not be great!