### PR TITLE
feat: add 'media' to allow image uploads

### DIFF
--- a/controllers/auth.php
+++ b/controllers/auth.php
@@ -76,7 +76,7 @@ $app->get('/auth/start', function() use($app) {
   $_SESSION['redirect_after_login'] = '/new';
 
   if($tokenEndpoint && $micropubEndpoint && $authorizationEndpoint) {
-    $scope = 'create';
+    $scope = 'create media';
     $authorizationURL = IndieAuth\Client::buildAuthorizationURL($authorizationEndpoint, [
       'me' => $me,
       'redirect_uri' => buildRedirectURI(),


### PR DESCRIPTION
Right now, I cannot add images using Teacup because I need the `media` scope for it. This adds that option.